### PR TITLE
Ajust sits_getdata from csv file.

### DIFF
--- a/R/sits_getdata.R
+++ b/R/sits_getdata.R
@@ -212,6 +212,11 @@ sits_getdata <- function (file        = NULL,
      csv.tb %>%
           purrr::by_row( function (r){
                row <- .sits_fromWTSS (r$longitude, r$latitude, r$start_date, r$end_date, r$label, wtss.obj, cov, bands)
+
+               # ajust the start and end dates
+               row$start_date <- lubridate::as_date(head(row$time_series[[1]]$Index, 1))
+               row$end_date   <- lubridate::as_date(tail(row$time_series[[1]]$Index, 1))
+
                data.tb <<- dplyr::bind_rows (data.tb, row)
           })
      return (data.tb)


### PR DESCRIPTION
Ajust sits_getdata from csv file. In order to store in start_date and end_date of the tibble, the dates provided by first and last rows of the time_series Index.  